### PR TITLE
Add tag management

### DIFF
--- a/fakeplayer-api/src/main/java/io/github/hello09x/fakeplayer/api/spi/NMSServerPlayer.java
+++ b/fakeplayer-api/src/main/java/io/github/hello09x/fakeplayer/api/spi/NMSServerPlayer.java
@@ -221,4 +221,32 @@ public interface NMSServerPlayer {
      */
     void swapItemWithOffhand();
 
+    /**
+     * 添加标签
+     * @param tag 标签
+     * @return 是否添加成功
+     */
+    boolean addTag(@NotNull String tag);
+
+    /**
+     * 移除标签
+     * @param tag 标签
+     * @return 是否移除成功
+     */
+    boolean removeTag(@NotNull String tag);
+
+    /**
+     * 是否拥有标签
+     * @param tag 标签
+     * @return 是否拥有
+     */
+    boolean hasTag(@NotNull String tag);
+
+    /**
+     * 获取所有标签
+     * @return 标签集合
+     */
+    @NotNull
+    java.util.Set<String> getTags();
+
 }

--- a/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/command/CommandRegistry.java
+++ b/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/command/CommandRegistry.java
@@ -79,6 +79,8 @@ public class CommandRegistry {
     private DebugCommand debugCommand;
     @Inject
     private StopCommand stopCommand;
+    @Inject
+    private TagCommand tagCommand;
 
     @Inject
     private FakeplayerConfig config;
@@ -457,8 +459,11 @@ public class CommandRegistry {
                                                         text("message")
                                                 )
                                                 .executes(debugCommand::sendPluginMessage)
-                                )
-
+                                ),
+                        command("tag")
+                                .withPermission(Permission.basic)
+                                .withShortDescription("管理假人标签")
+                                .executesPlayer((player, args) -> tagCommand.getCommand().execute(player, args))
                 );
         HelpCommand.generateHelpCommand(root, true);
         root.register();

--- a/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/command/impl/TagCommand.java
+++ b/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/command/impl/TagCommand.java
@@ -1,0 +1,91 @@
+package io.github.hello09x.fakeplayer.core.command.impl;
+
+import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.CommandPermission;
+import dev.jorel.commandapi.arguments.StringArgument;
+import io.github.hello09x.fakeplayer.core.entity.Fakeplayer;
+import io.github.hello09x.fakeplayer.core.manager.FakeplayerManager;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.format.NamedTextColor.*;
+
+public class TagCommand {
+    private final FakeplayerManager manager;
+
+    public TagCommand(FakeplayerManager manager) {
+        this.manager = manager;
+    }
+
+    public CommandAPICommand getCommand() {
+        return new CommandAPICommand("tag")
+                .withPermission(CommandPermission.fromString("fakeplayer.command.tag"))
+                .withSubcommand(new CommandAPICommand("add")
+                        .withArguments(new StringArgument("tag"))
+                        .withOptionalArguments(new StringArgument("--all").setOptional(true))
+                        .executesPlayer((player, args) -> {
+                            String tag = (String) args.get(0);
+                            boolean all = args.size() > 1 && "--all".equals(args.get(1));
+                            if (all) {
+                                var list = manager.getAll(player);
+                                int success = 0, exist = 0;
+                                for (var p : list) {
+                                    var fake = manager.getByOwner(p);
+                                    if (fake != null) {
+                                        if (fake.getHandle().addTag(tag)) success++;
+                                        else exist++;
+                                    }
+                                }
+                                player.sendMessage(text("批量添加标签: " + tag + "，成功 " + success + " 个，已存在 " + exist + " 个", GREEN));
+                            } else {
+                                Fakeplayer fake = getSelfFakeplayer(player);
+                                if (fake == null) return;
+                                if (fake.getHandle().addTag(tag)) {
+                                    player.sendMessage(text("已添加标签: " + tag, GREEN));
+                                } else {
+                                    player.sendMessage(text("标签已存在: " + tag, YELLOW));
+                                }
+                            }
+                        })
+                )
+                .withSubcommand(new CommandAPICommand("remove")
+                        .withArguments(new StringArgument("tag"))
+                        .executesPlayer((player, args) -> {
+                            Fakeplayer fake = getSelfFakeplayer(player);
+                            if (fake == null) return;
+                            String tag = (String) args.get(0);
+                            if (fake.getHandle().removeTag(tag)) {
+                                player.sendMessage(text("已移除标签: " + tag, GREEN));
+                            } else {
+                                player.sendMessage(text("标签不存在: " + tag, YELLOW));
+                            }
+                        })
+                )
+                .withSubcommand(new CommandAPICommand("list")
+                        .executesPlayer((player, args) -> {
+                            Fakeplayer fake = getSelfFakeplayer(player);
+                            if (fake == null) return;
+                            Set<String> tags = fake.getHandle().getTags();
+                            if (tags.isEmpty()) {
+                                player.sendMessage(text("当前没有标签", GRAY));
+                            } else {
+                                player.sendMessage(text("标签: " + String.join(", ", tags), AQUA));
+                            }
+                        })
+                );
+    }
+
+    private Fakeplayer getSelfFakeplayer(@NotNull Player player) {
+        Fakeplayer fake = manager.getByOwner(player);
+        if (fake == null) {
+            player.sendMessage(text("你没有可操作的假人", RED));
+            return null;
+        }
+        return fake;
+    }
+}

--- a/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/command/impl/TagCommandProvider.java
+++ b/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/command/impl/TagCommandProvider.java
@@ -1,0 +1,15 @@
+package io.github.hello09x.fakeplayer.core.command.impl;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.github.hello09x.fakeplayer.core.manager.FakeplayerManager;
+
+public class TagCommandProvider implements Provider<TagCommand> {
+    @Inject
+    private FakeplayerManager manager;
+
+    @Override
+    public TagCommand get() {
+        return new TagCommand(manager);
+    }
+}

--- a/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/manager/FakeplayerManager.java
+++ b/fakeplayer-core/src/main/java/io/github/hello09x/fakeplayer/core/manager/FakeplayerManager.java
@@ -490,4 +490,26 @@ public class FakeplayerManager {
         Exceptions.suppress(Main.getInstance(), this.lagMonitor::shutdownNow);
     }
 
+    /**
+     * 获取玩家当前选中的假人（如果没有则取第一个自己创建的假人）
+     */
+    public Fakeplayer getByOwner(Player player) {
+        Player selected = getSelection(player);
+        if (selected != null) {
+            return this.playerList.getByUUID(selected.getUniqueId());
+        }
+        // 没有选中则取第一个自己创建的
+        List<Fakeplayer> list = this.playerList.getByCreator(player.getName());
+        return list.isEmpty() ? null : list.get(0);
+    }
+
+    /**
+     * 获取玩家自己创建且带指定标签的所有假人
+     */
+    public List<Fakeplayer> getByTag(@NotNull CommandSender owner, @NotNull String tag) {
+        return this.playerList.getByCreator(owner.getName())
+                .stream()
+                .filter(fp -> fp.getHandle().hasTag(tag))
+                .toList();
+    }
 }

--- a/fakeplayer-v1_21_5/src/main/java/io/github/hello09x/fakeplayer/v1_21_5/spi/NMSServerPlayerImpl.java
+++ b/fakeplayer-v1_21_5/src/main/java/io/github/hello09x/fakeplayer/v1_21_5/spi/NMSServerPlayerImpl.java
@@ -251,4 +251,24 @@ public class NMSServerPlayerImpl implements NMSServerPlayer {
         ));
     }
 
+    @Override
+    public boolean addTag(@NotNull String tag) {
+        return handle.addTag(tag);
+    }
+
+    @Override
+    public boolean removeTag(@NotNull String tag) {
+        return handle.removeTag(tag);
+    }
+
+    @Override
+    public boolean hasTag(@NotNull String tag) {
+        return handle.getTags().contains(tag);
+    }
+
+    @Override
+    public @NotNull java.util.Set<String> getTags() {
+        return handle.getTags();
+    }
+
 }


### PR DESCRIPTION
假人标签批量操作与标签选择

/fp tag add <标签> --all：支持一键为自己所有假人批量添加标签。
指令参数支持标签选择

大部分假人相关指令（如 select、kill、drop、move、stop、attack 等）均支持 *标签 语法。
例如 /fp select *Q 会选中所有带 Q 标签的假人，实现批量操作。
补全也会自动提示带 * 的标签名。
