### PR TITLE
Apply dynamic fakeplayer limits to server lag

### DIFF
--- a/fakeplayer-core/src/main/resources/config.yml
+++ b/fakeplayer-core/src/main/resources/config.yml
@@ -135,10 +135,10 @@ persistent-data: true
 kick-on-dead: true
 
 
-# 服务器最近 5 分钟平均 TPS 低于这个值清除所有假人
-# 每 60 秒检测一次
+# 服务器最近 1 分钟平均 TPS 低于这个值将降低 1 假人上限，玩家超出上限的假人将被移除
+# 每 60 秒检测一次，持续卡顿将降低假人上限降直至 0；无卡顿则恢复 1 上限直至初始值
 # 默认: 0, 即不开启, 因为移除假人可能导致玩家红石机器出问题, 按需开启吧
-# Server will detect tps every 5 minutes, if the average tps is lower than this value, all fake players will be removed
+# Server will detect tps every 5 minutes, if the average tps is lower than this value, fakeplayer limits will gradually reduce to 0
 # Default: 0, means disabled
 # Tips:
 #    It's not recommended to enable this option, as it may cause the redstone machine to malfunction


### PR DESCRIPTION
[https://github.com/tanyaofei/minecraft-fakeplayer/issues/120](url)

When server lag detected, plugin will now gradually reduce fakeplayer limits to 0, instead of removing all at a time.
When lag no longer persists, limits would restore every minutes.This will bring a smoother playing experience.

这个版本引入了动态假人上限，服务器卡顿将逐渐降低玩家假人上限而不是全部移除，玩家召唤假人数量超出降低后的上限则会移除；卡顿消失后逐渐恢复假人上限，此方案能更丝滑地使用假人。为配合此功能快速响应，服务器卡顿检测对象改为过去一分钟平均TPS。

服务器实测截图：
![fda550125bb46c2fca4f2efaa3cb0e3e](https://github.com/user-attachments/assets/9b94bc26-1fc0-408c-9973-762f68fa3564)
![f759d9feed71d829d8d88f79275ff0b1](https://github.com/user-attachments/assets/7a34f5a9-2bb0-4da9-9906-53e5c02f66f9)
